### PR TITLE
Add Congress Legislators CSV to Parquet converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,19 @@ This repository provides:
 - Campaign contributions (1979-2024) - 915 million transaction records
 - Politicians/Recipients - Federal candidates who received contributions
 - Donors/Contributors - Individuals and organizations making contributions
-- Available on [Huggingface](https://huggingface.co/datasets/Dustinhax/tyt/tree/main/tyt/dime)
+- Available on [Huggingface](https://huggingface.co/datasets/Dustinhax/tyt/tree/main/dime)
 
 **Voteview** (Congressional Roll-Call Voting)
 - Roll call voting records (1789-present) - 26M individual vote records
 - Congressional member info with NOMINATE ideology scores - 51K members
 - Roll call metadata with vote descriptions - 113K roll calls
-- Available on [Huggingface](https://huggingface.co/datasets/Dustinhax/tyt/tree/main/tyt/voteview)
+- Available on [Huggingface](https://huggingface.co/datasets/Dustinhax/tyt/tree/main/voteview)
+
+**United States Congress Legislators**
+- Currently serving legislators - 540 members
+- Historical legislators (all time) - 12,222 members
+- Cross-reference IDs: bioguide_id, icpsr_id (links to Voteview)
+- Available on [Huggingface](https://huggingface.co/datasets/Dustinhax/tyt/tree/main/unitedstates_congress_github)
 
 #### Coming Soon
 
@@ -110,6 +116,7 @@ Data sources explored but not yet integrated:
 - **LDA LD-203** - Lobbying contribution reports
 - **SEC** - CIK/Ticker reference data
 - **GLEIF LEI** - Legal Entity Identifier (CC0)
+- **United States Congress Legislators** - [github.com/unitedstates/congress-legislators](https://github.com/unitedstates/congress-legislators)
 
 ### Open License (Non-Commercial)
 - **Voteview** - CC BY-NC 4.0 (attribution required, non-commercial only)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [{ name = "Paper Trail Contributors" }]
 
 dependencies = [
     "duckdb-loader",
+    "huggingface-hub>=1.2.3",
 ]
 
 [project.optional-dependencies]

--- a/scripts/congress_legislators_converter/README.md
+++ b/scripts/congress_legislators_converter/README.md
@@ -1,0 +1,110 @@
+# Congress Legislators CSV to Parquet Converter
+
+Converts Congress Legislators data from [unitedstates/congress-legislators](https://github.com/unitedstates/congress-legislators) CSV format to Parquet with lossless validation.
+
+## Data Source
+
+- **URL**: https://unitedstates.github.io/congress-legislators/
+- **Files**:
+  - `legislators-current.csv` - Currently serving legislators (~540 rows)
+  - `legislators-historical.csv` - All historical legislators (~12,500 rows)
+
+## Installation
+
+```bash
+cd scripts/congress_legislators_converter
+uv pip install pyarrow
+```
+
+## Usage
+
+### Download and Convert All Files
+
+```bash
+uv run -m congress_legislators_converter all --output-dir ./data
+```
+
+### Download Only
+
+```bash
+# Download all files
+uv run -m congress_legislators_converter download --output-dir ./data
+
+# Download specific file
+uv run -m congress_legislators_converter download --output-dir ./data -t current
+```
+
+### Convert Only
+
+```bash
+uv run -m congress_legislators_converter convert legislators-current.csv legislators-current.parquet
+```
+
+### Options
+
+- `--no-validate`: Skip validation (not recommended)
+- `--sample-size N`: Number of rows to sample for validation
+- `--batch-size N`: Rows per batch for streaming (default: 100,000)
+
+## Schema
+
+All 36 columns are stored as strings for lossless conversion:
+
+| Column | Description |
+|--------|-------------|
+| `last_name` | Legislator's last name |
+| `first_name` | First name |
+| `middle_name` | Middle name |
+| `suffix` | Name suffix (Jr., Sr., etc.) |
+| `nickname` | Common nickname |
+| `full_name` | Complete display name |
+| `birthday` | Birth date (YYYY-MM-DD) |
+| `gender` | M/F |
+| `type` | sen (Senator) or rep (Representative) |
+| `state` | 2-letter state code |
+| `district` | Congressional district (representatives only) |
+| `senate_class` | Senate class 1/2/3 (senators only) |
+| `party` | Political party |
+| `url` | Official website URL |
+| `address` | Office address |
+| `phone` | Office phone number |
+| `contact_form` | Contact form URL |
+| `rss_url` | RSS feed URL |
+| `twitter` | Twitter handle |
+| `twitter_id` | Twitter numeric ID |
+| `facebook` | Facebook handle |
+| `youtube` | YouTube channel |
+| `youtube_id` | YouTube channel ID |
+| `mastodon` | Mastodon handle |
+| `bioguide_id` | Biographical Directory ID (primary key) |
+| `thomas_id` | THOMAS system ID |
+| `opensecrets_id` | OpenSecrets CRP ID |
+| `lis_id` | Legislative Information System ID |
+| `fec_ids` | FEC candidate IDs (comma-separated) |
+| `cspan_id` | C-SPAN ID |
+| `govtrack_id` | GovTrack ID |
+| `votesmart_id` | VoteSmart ID |
+| `ballotpedia_id` | Ballotpedia ID |
+| `washington_post_id` | Washington Post ID |
+| `icpsr_id` | ICPSR ID (for Voteview cross-reference) |
+| `wikipedia_id` | Wikipedia article title |
+
+## Validation
+
+Three-tier validation ensures lossless conversion:
+
+1. **Row Count**: Verifies Parquet row count matches source CSV
+2. **Checksums**: Verifies non-null counts for key columns (bioguide_id, icpsr_id, state, type)
+3. **Sample Comparison**: Field-by-field comparison of random rows
+
+## Output Format
+
+- **Compression**: zstd level 3
+- **All columns**: String type (pa.string())
+- **Null handling**: Empty strings converted to null
+
+## Cross-references
+
+The `icpsr_id` column can be used to join with Voteview data:
+- Voteview Members: `icpsr` column
+- Voteview Votes: `icpsr` column

--- a/scripts/congress_legislators_converter/__init__.py
+++ b/scripts/congress_legislators_converter/__init__.py
@@ -1,0 +1,62 @@
+"""Congress Legislators CSV to Parquet converter with streaming and validation.
+
+This module provides tools for downloading and converting Congress Legislators
+data from unitedstates.github.io to Parquet format, with lossless conversion
+guaranteed through three-tier validation.
+
+Supported file types:
+- current: Currently serving legislators
+- historical: All historical legislators
+
+Data source: https://unitedstates.github.io/congress-legislators/
+
+Example usage:
+    from congress_legislators_converter import (
+        convert_legislators_file,
+        download_file,
+        FileType,
+    )
+
+    # Download and convert
+    csv_path = download_file(FileType.CURRENT, Path("./data"))
+    result = convert_legislators_file(
+        csv_path,
+        "legislators-current.parquet",
+        FileType.CURRENT,
+    )
+    print(f"Converted {result.row_count:,} rows")
+"""
+
+from .converter import ConversionResult, StreamingStats, convert_legislators_file
+from .downloader import download_all, download_file
+from .exceptions import (
+    ChecksumMismatchError,
+    CongressLegislatorsConversionError,
+    CSVParseError,
+    DownloadError,
+    RowCountMismatchError,
+    SampleMismatchError,
+    SchemaValidationError,
+)
+from .schema import FileType, FileTypeConfig, get_config
+
+__all__ = [
+    # Core functions
+    "convert_legislators_file",
+    "download_file",
+    "download_all",
+    "get_config",
+    # Data classes
+    "ConversionResult",
+    "FileType",
+    "FileTypeConfig",
+    "StreamingStats",
+    # Exceptions
+    "CongressLegislatorsConversionError",
+    "CSVParseError",
+    "ChecksumMismatchError",
+    "DownloadError",
+    "RowCountMismatchError",
+    "SampleMismatchError",
+    "SchemaValidationError",
+]

--- a/scripts/congress_legislators_converter/__main__.py
+++ b/scripts/congress_legislators_converter/__main__.py
@@ -1,0 +1,12 @@
+"""Entry point for running the Congress Legislators converter as a module.
+
+Usage:
+    python -m congress_legislators_converter download --output-dir ./data
+    python -m congress_legislators_converter convert source.csv output.parquet
+    python -m congress_legislators_converter all --output-dir ./data
+"""
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/congress_legislators_converter/cli.py
+++ b/scripts/congress_legislators_converter/cli.py
@@ -1,0 +1,245 @@
+"""Command-line interface for Congress Legislators CSV to Parquet converter."""
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from .converter import convert_legislators_file
+from .downloader import download_all, download_file
+from .exceptions import CongressLegislatorsConversionError, DownloadError
+from .schema import FileType
+
+
+def detect_file_type(filename: str) -> FileType:
+    """
+    Auto-detect file type from filename.
+
+    Recognizes patterns like:
+    - legislators-current.csv -> CURRENT
+    - legislators-historical.csv -> HISTORICAL
+    """
+    name_lower = filename.lower()
+    if "current" in name_lower:
+        return FileType.CURRENT
+    if "historical" in name_lower:
+        return FileType.HISTORICAL
+    raise ValueError(f"Cannot auto-detect file type from: {filename}")
+
+
+def cmd_download(args: argparse.Namespace) -> int:
+    """Handle the download subcommand."""
+    output_dir = Path(args.output_dir)
+    print(f"[{datetime.now().isoformat()}] Downloading legislators data...")
+
+    try:
+        if args.file_type:
+            file_type = FileType(args.file_type)
+            path = download_file(file_type, output_dir)
+            print(f"  Downloaded: {path}")
+        else:
+            paths = download_all(output_dir)
+            for ft, path in paths.items():
+                print(f"  Downloaded {ft.value}: {path}")
+
+        print(f"[{datetime.now().isoformat()}] Download complete")
+        return 0
+
+    except DownloadError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+
+def cmd_convert(args: argparse.Namespace) -> int:
+    """Handle the convert subcommand."""
+    source_path = Path(args.source)
+    output_path = Path(args.output)
+
+    # Validate source exists
+    if not source_path.exists():
+        print(f"ERROR: Source file not found: {source_path}", file=sys.stderr)
+        return 1
+
+    # Determine file type
+    if args.file_type:
+        file_type = FileType(args.file_type)
+    else:
+        try:
+            file_type = detect_file_type(source_path.name)
+        except ValueError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            print("Use -t/--file-type to specify explicitly", file=sys.stderr)
+            return 1
+
+    print(f"[{datetime.now().isoformat()}] Converting: {source_path.name}")
+    print(f"  File type: {file_type.value}")
+
+    try:
+        result = convert_legislators_file(
+            source_path,
+            output_path,
+            file_type,
+            validate=not args.no_validate,
+            sample_size=args.sample_size,
+            batch_size=args.batch_size,
+        )
+
+        print(f"[{datetime.now().isoformat()}] SUCCESS: {result.row_count:,} rows")
+        print(f"  Output: {result.output_path}")
+
+        if args.no_validate:
+            print("  Validation: SKIPPED")
+        else:
+            print("  Validation: ALL PASSED")
+
+        return 0
+
+    except CongressLegislatorsConversionError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+
+def cmd_all(args: argparse.Namespace) -> int:
+    """Handle the all subcommand (download + convert all files)."""
+    output_dir = Path(args.output_dir)
+    print(f"[{datetime.now().isoformat()}] Processing all legislators data...")
+
+    try:
+        # Step 1: Download all files
+        print("\n=== Downloading ===")
+        csv_paths = download_all(output_dir)
+
+        # Step 2: Convert all files
+        print("\n=== Converting ===")
+        for file_type, csv_path in csv_paths.items():
+            parquet_path = output_dir / f"legislators-{file_type.value}.parquet"
+
+            print(f"\n[{datetime.now().isoformat()}] Converting: {csv_path.name}")
+            print(f"  File type: {file_type.value}")
+
+            result = convert_legislators_file(
+                csv_path,
+                parquet_path,
+                file_type,
+                validate=not args.no_validate,
+                sample_size=args.sample_size,
+                batch_size=args.batch_size,
+            )
+
+            print(f"  SUCCESS: {result.row_count:,} rows -> {parquet_path.name}")
+
+        print(f"\n[{datetime.now().isoformat()}] All conversions complete")
+        return 0
+
+    except (DownloadError, CongressLegislatorsConversionError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+
+def main() -> int:
+    """Main entry point for the CLI."""
+    parser = argparse.ArgumentParser(
+        description="Download and convert Congress Legislators data to Parquet",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Download subcommand
+    download_parser = subparsers.add_parser(
+        "download",
+        help="Download CSV files from unitedstates.github.io",
+    )
+    download_parser.add_argument(
+        "--output-dir",
+        "-o",
+        type=str,
+        default=".",
+        help="Directory to save downloaded files (default: current directory)",
+    )
+    download_parser.add_argument(
+        "-t",
+        "--file-type",
+        choices=["current", "historical"],
+        default=None,
+        help="Specific file type to download (downloads all if not specified)",
+    )
+    download_parser.set_defaults(func=cmd_download)
+
+    # Convert subcommand
+    convert_parser = subparsers.add_parser(
+        "convert",
+        help="Convert a CSV file to Parquet format",
+    )
+    convert_parser.add_argument(
+        "source",
+        type=str,
+        help="Source CSV file path",
+    )
+    convert_parser.add_argument(
+        "output",
+        type=str,
+        help="Output Parquet file path",
+    )
+    convert_parser.add_argument(
+        "-t",
+        "--file-type",
+        choices=["current", "historical"],
+        default=None,
+        help="Type of file (auto-detected from filename if not specified)",
+    )
+    convert_parser.add_argument(
+        "--no-validate",
+        action="store_true",
+        help="Skip validation (not recommended)",
+    )
+    convert_parser.add_argument(
+        "--sample-size",
+        type=int,
+        default=None,
+        help="Number of rows to sample for validation",
+    )
+    convert_parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100_000,
+        help="Rows per batch for streaming conversion (default: 100000)",
+    )
+    convert_parser.set_defaults(func=cmd_convert)
+
+    # All subcommand (download + convert)
+    all_parser = subparsers.add_parser(
+        "all",
+        help="Download and convert all files",
+    )
+    all_parser.add_argument(
+        "--output-dir",
+        "-o",
+        type=str,
+        default=".",
+        help="Directory for downloads and conversions (default: current directory)",
+    )
+    all_parser.add_argument(
+        "--no-validate",
+        action="store_true",
+        help="Skip validation (not recommended)",
+    )
+    all_parser.add_argument(
+        "--sample-size",
+        type=int,
+        default=None,
+        help="Number of rows to sample for validation",
+    )
+    all_parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100_000,
+        help="Rows per batch for streaming conversion (default: 100000)",
+    )
+    all_parser.set_defaults(func=cmd_all)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/congress_legislators_converter/converter.py
+++ b/scripts/congress_legislators_converter/converter.py
@@ -1,0 +1,244 @@
+"""Core Congress Legislators CSV to Parquet conversion logic with streaming."""
+
+import csv
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.csv as pa_csv
+import pyarrow.parquet as pq
+
+from .exceptions import CSVParseError, SchemaValidationError
+from .schema import (
+    NULL_VALUES,
+    FileType,
+    FileTypeConfig,
+    get_config,
+)
+from .validators import (
+    ValidationResult,
+    validate_checksums,
+    validate_row_count,
+    validate_sample_rows,
+)
+
+
+@dataclass
+class StreamingStats:
+    """Statistics accumulated during streaming conversion."""
+
+    row_count: int = 0
+    sum_column_value: float = 0.0
+    non_null_counts: dict[str, int] = field(default_factory=dict)
+    schema: pa.Schema | None = None
+
+
+@dataclass
+class ConversionResult:
+    """Result of a successful conversion."""
+
+    source_path: Path
+    output_path: Path
+    row_count: int
+    validation: ValidationResult
+
+
+def convert_legislators_file(
+    source_path: Path | str,
+    output_path: Path | str,
+    file_type: FileType,
+    *,
+    validate: bool = True,
+    sample_size: int | None = None,
+    batch_size: int = 100_000,
+) -> ConversionResult:
+    """
+    Convert a Congress Legislators CSV file to Parquet format using streaming.
+
+    Args:
+        source_path: Path to input CSV file
+        output_path: Path for output .parquet file
+        file_type: Type of legislators file (CURRENT or HISTORICAL)
+        validate: Whether to run validation suite after conversion
+        sample_size: Number of random rows to compare (uses config default if None)
+        batch_size: Number of rows to process per batch
+
+    Returns:
+        ConversionResult with conversion details and validation results
+
+    Raises:
+        CongressLegislatorsConversionError: If conversion or validation fails
+    """
+    source_path = Path(source_path)
+    output_path = Path(output_path)
+
+    config = get_config(file_type)
+    actual_sample_size = sample_size or config.sample_size
+
+    # Step 1: Pre-flight row count
+    print(f"  Counting rows in {source_path.name}...")
+    expected_row_count = _count_csv_rows(source_path)
+    print(f"  Found {expected_row_count:,} rows")
+
+    # Step 2: Stream CSV to Parquet
+    print(f"  Streaming CSV to Parquet (batch size: {batch_size:,})...")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    stats = _stream_csv_to_parquet(source_path, output_path, batch_size, config)
+    print(f"  Written {stats.row_count:,} rows to {output_path}")
+
+    # Step 3: Validate schema
+    _validate_schema(source_path, stats.schema, config)
+
+    # Step 4: Validate output
+    validation_result = ValidationResult()
+    if validate:
+        print("  Validating...")
+
+        validation_result = validate_row_count(source_path, output_path, expected_row_count)
+        print(f"    Row count: PASS ({validation_result.row_count_actual:,})")
+
+        validation_result = validate_checksums(
+            source_path,
+            output_path,
+            stats,
+            validation_result,
+            sum_column=config.sum_column,
+            key_columns=config.key_columns,
+        )
+        print("    Checksums: PASS (non-null counts verified)")
+
+        validation_result = validate_sample_rows(
+            source_path, output_path, actual_sample_size, validation_result
+        )
+        print(f"    Sample comparison: PASS ({validation_result.sample_size} rows)")
+
+    return ConversionResult(
+        source_path=source_path,
+        output_path=output_path,
+        row_count=stats.row_count,
+        validation=validation_result,
+    )
+
+
+def _count_csv_rows(path: Path) -> int:
+    """Count data rows in plain CSV file (excluding header)."""
+    count = 0
+    with path.open(encoding="utf-8") as f:
+        reader = csv.reader(f, doublequote=True)
+        next(reader)  # Skip header
+        for _ in reader:
+            count += 1
+    return count
+
+
+def _stream_csv_to_parquet(
+    source_path: Path,
+    output_path: Path,
+    batch_size: int,
+    config: FileTypeConfig,
+) -> StreamingStats:
+    """Stream CSV to Parquet without loading entire file into memory."""
+    invalid_rows: list[tuple[int, str]] = []
+
+    def invalid_row_handler(row: pa_csv.InvalidRow) -> str:
+        invalid_rows.append((row.number, str(row.text)[:500]))
+        return "error"
+
+    read_options = pa_csv.ReadOptions(
+        encoding="utf-8",
+        block_size=batch_size * 1024,
+    )
+    parse_options = pa_csv.ParseOptions(
+        double_quote=True,
+        invalid_row_handler=invalid_row_handler,
+    )
+    convert_options = pa_csv.ConvertOptions(
+        null_values=NULL_VALUES,
+        strings_can_be_null=True,
+        column_types=config.schema,
+    )
+
+    stats = StreamingStats()
+    for col in config.key_columns:
+        stats.non_null_counts[col] = 0
+
+    writer: pq.ParquetWriter | None = None
+
+    try:
+        reader = pa_csv.open_csv(
+            source_path,
+            read_options=read_options,
+            parse_options=parse_options,
+            convert_options=convert_options,
+        )
+
+        batch_num = 0
+        for batch in reader:
+            batch_num += 1
+
+            if writer is None:
+                stats.schema = batch.schema
+                writer = pq.ParquetWriter(
+                    output_path,
+                    schema=batch.schema,
+                    compression="zstd",
+                    compression_level=3,
+                )
+
+            table = pa.Table.from_batches([batch])
+            writer.write_table(table)
+
+            stats.row_count += batch.num_rows
+
+            # Sum column for checksum (not applicable for string-only datasets)
+            if config.sum_column and config.sum_column in batch.schema.names:
+                sum_col = batch.column(config.sum_column)
+                batch_sum = pc.sum(sum_col).as_py()
+                if batch_sum is not None:
+                    stats.sum_column_value += batch_sum
+
+            # Non-null counts for key columns
+            for col in config.key_columns:
+                if col in batch.schema.names:
+                    col_data = batch.column(col)
+                    count = pc.count(col_data).as_py()
+                    stats.non_null_counts[col] += count
+
+            # Progress every 10 batches
+            if batch_num % 10 == 0:
+                print(f"    Processed {stats.row_count:,} rows...", flush=True)
+
+    except pa.ArrowInvalid as e:
+        raise CSVParseError(
+            source_path=source_path,
+            message=f"PyArrow CSV parse error: {e}",
+            line_number=invalid_rows[0][0] if invalid_rows else None,
+            problematic_value=invalid_rows[0][1] if invalid_rows else None,
+        ) from e
+
+    finally:
+        if writer is not None:
+            writer.close()
+
+    return stats
+
+
+def _validate_schema(path: Path, schema: pa.Schema | None, config: FileTypeConfig) -> None:
+    """Validate that table schema matches expected columns."""
+    if schema is None:
+        raise SchemaValidationError(
+            source_path=path,
+            message="No schema captured - file may be empty",
+            expected_columns=config.expected_columns,
+            actual_columns=[],
+        )
+
+    actual_columns = schema.names
+    if set(actual_columns) != set(config.expected_columns):
+        raise SchemaValidationError(
+            source_path=path,
+            message="Column schema mismatch",
+            expected_columns=config.expected_columns,
+            actual_columns=actual_columns,
+        )

--- a/scripts/congress_legislators_converter/downloader.py
+++ b/scripts/congress_legislators_converter/downloader.py
@@ -1,0 +1,83 @@
+"""Download Congress Legislators CSV files from unitedstates.github.io."""
+
+from pathlib import Path
+from urllib.request import urlopen
+
+from .exceptions import DownloadError
+from .schema import FILE_URLS, FileType
+
+
+def download_file(file_type: FileType, output_dir: Path) -> Path:
+    """
+    Download a Congress Legislators CSV file.
+
+    Args:
+        file_type: Type of file to download (CURRENT or HISTORICAL)
+        output_dir: Directory to save the downloaded file
+
+    Returns:
+        Path to the downloaded file
+
+    Raises:
+        DownloadError: If download fails
+    """
+    url = FILE_URLS[file_type]
+    filename = f"legislators-{file_type.value}.csv"
+    output_path = output_dir / filename
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"  Downloading {filename} from {url}...")
+
+    try:
+        with urlopen(url, timeout=60) as response:
+            if response.status != 200:
+                raise DownloadError(
+                    source_path=output_path,
+                    message="HTTP error downloading file",
+                    url=url,
+                    status_code=response.status,
+                )
+
+            content = response.read()
+            output_path.write_bytes(content)
+
+            size_kb = len(content) / 1024
+            print(f"  Downloaded {size_kb:.1f} KB to {output_path}")
+
+    except TimeoutError as e:
+        raise DownloadError(
+            source_path=output_path,
+            message="Download timed out",
+            url=url,
+        ) from e
+    except OSError as e:
+        raise DownloadError(
+            source_path=output_path,
+            message=f"Network error: {e}",
+            url=url,
+        ) from e
+
+    return output_path
+
+
+def download_all(output_dir: Path) -> dict[FileType, Path]:
+    """
+    Download all Congress Legislators CSV files.
+
+    Args:
+        output_dir: Directory to save the downloaded files
+
+    Returns:
+        Dictionary mapping FileType to downloaded file paths
+
+    Raises:
+        DownloadError: If any download fails
+    """
+    results: dict[FileType, Path] = {}
+
+    for file_type in FileType:
+        path = download_file(file_type, output_dir)
+        results[file_type] = path
+
+    return results

--- a/scripts/congress_legislators_converter/exceptions.py
+++ b/scripts/congress_legislators_converter/exceptions.py
@@ -1,0 +1,122 @@
+"""Custom exception types for Congress Legislators conversion errors with detailed context."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class CongressLegislatorsConversionError(Exception):
+    """Base exception for Congress Legislators conversion errors."""
+
+    source_path: Path
+    message: str
+
+    def __str__(self) -> str:
+        return f"[{self.source_path.name}] {self.message}"
+
+
+@dataclass
+class DownloadError(CongressLegislatorsConversionError):
+    """Error downloading file from remote source."""
+
+    url: str | None = None
+    status_code: int | None = None
+
+    def __str__(self) -> str:
+        parts = [f"[{self.source_path.name}] {self.message}"]
+        if self.url:
+            parts.append(f"URL: {self.url}")
+        if self.status_code:
+            parts.append(f"Status: {self.status_code}")
+        return " | ".join(parts)
+
+
+@dataclass
+class CSVParseError(CongressLegislatorsConversionError):
+    """Error parsing CSV file."""
+
+    line_number: int | None = None
+    column_name: str | None = None
+    problematic_value: str | None = None
+
+    def __str__(self) -> str:
+        parts = [f"[{self.source_path.name}]"]
+        if self.line_number:
+            parts.append(f"line {self.line_number}")
+        if self.column_name:
+            parts.append(f"column '{self.column_name}'")
+        if self.problematic_value:
+            val = self.problematic_value[:100]
+            if len(self.problematic_value) > 100:
+                val += "..."
+            parts.append(f"value: {val!r}")
+        parts.append(self.message)
+        return " ".join(parts)
+
+
+@dataclass
+class RowCountMismatchError(CongressLegislatorsConversionError):
+    """Row count validation failed."""
+
+    expected_rows: int = 0
+    actual_rows: int = 0
+
+    def __str__(self) -> str:
+        diff = self.expected_rows - self.actual_rows
+        return (
+            f"[{self.source_path.name}] Row count mismatch: "
+            f"expected {self.expected_rows:,}, got {self.actual_rows:,} "
+            f"(difference: {diff:,})"
+        )
+
+
+@dataclass
+class ChecksumMismatchError(CongressLegislatorsConversionError):
+    """Column checksum validation failed."""
+
+    column_name: str = ""
+    expected_value: float | int = 0
+    actual_value: float | int = 0
+
+    def __str__(self) -> str:
+        return (
+            f"[{self.source_path.name}] Checksum mismatch for '{self.column_name}': "
+            f"expected {self.expected_value}, got {self.actual_value}"
+        )
+
+
+@dataclass
+class SampleMismatchError(CongressLegislatorsConversionError):
+    """Sample row comparison failed."""
+
+    row_index: int = 0
+    column_name: str = ""
+    expected_value: str = ""
+    actual_value: str = ""
+
+    def __str__(self) -> str:
+        return (
+            f"[{self.source_path.name}] Sample mismatch at row {self.row_index}, "
+            f"column '{self.column_name}': expected {self.expected_value!r}, "
+            f"got {self.actual_value!r}"
+        )
+
+
+@dataclass
+class SchemaValidationError(CongressLegislatorsConversionError):
+    """Schema validation failed."""
+
+    expected_columns: list[str] | None = None
+    actual_columns: list[str] | None = None
+
+    def __str__(self) -> str:
+        expected = set(self.expected_columns or [])
+        actual = set(self.actual_columns or [])
+        missing = expected - actual
+        extra = actual - expected
+        parts = [f"[{self.source_path.name}] Schema mismatch:"]
+        if missing:
+            parts.append(f"missing columns: {sorted(missing)}")
+        if extra:
+            parts.append(f"extra columns: {sorted(extra)}")
+        return " ".join(parts)

--- a/scripts/congress_legislators_converter/schema.py
+++ b/scripts/congress_legislators_converter/schema.py
@@ -1,0 +1,152 @@
+"""Congress Legislators schema definitions with explicit PyArrow types."""
+
+from dataclasses import dataclass
+from enum import Enum
+
+import pyarrow as pa
+
+
+class FileType(Enum):
+    """Supported Congress Legislators file types."""
+
+    CURRENT = "current"
+    HISTORICAL = "historical"
+
+
+# =============================================================================
+# LEGISLATORS SCHEMA (36 columns)
+# =============================================================================
+# All columns stored as strings for lossless conversion.
+# IDs kept as strings to preserve any leading zeros or special formats.
+# Dates kept as strings since some historical dates may be incomplete.
+LEGISLATORS_SCHEMA: dict[str, pa.DataType] = {
+    # Name fields
+    "last_name": pa.string(),
+    "first_name": pa.string(),
+    "middle_name": pa.string(),
+    "suffix": pa.string(),
+    "nickname": pa.string(),
+    "full_name": pa.string(),
+    # Demographics
+    "birthday": pa.string(),  # YYYY-MM-DD format, keep as string for incomplete dates
+    "gender": pa.string(),  # M/F
+    # Position information
+    "type": pa.string(),  # sen/rep
+    "state": pa.string(),  # 2-letter code
+    "district": pa.string(),  # Keep as string (nullable)
+    "senate_class": pa.string(),  # 1/2/3 or empty
+    "party": pa.string(),  # Various values including historical parties
+    # Contact information
+    "url": pa.string(),
+    "address": pa.string(),
+    "phone": pa.string(),
+    "contact_form": pa.string(),
+    "rss_url": pa.string(),
+    # Social media
+    "twitter": pa.string(),
+    "twitter_id": pa.string(),
+    "facebook": pa.string(),
+    "youtube": pa.string(),
+    "youtube_id": pa.string(),
+    "mastodon": pa.string(),
+    # Identifier fields - all kept as strings
+    "bioguide_id": pa.string(),  # Primary identifier (e.g., C000127)
+    "thomas_id": pa.string(),
+    "opensecrets_id": pa.string(),
+    "lis_id": pa.string(),
+    "fec_ids": pa.string(),  # May contain multiple comma-separated IDs
+    "cspan_id": pa.string(),
+    "govtrack_id": pa.string(),
+    "votesmart_id": pa.string(),
+    "ballotpedia_id": pa.string(),
+    "washington_post_id": pa.string(),
+    "icpsr_id": pa.string(),  # Cross-reference with Voteview
+    "wikipedia_id": pa.string(),
+}
+
+LEGISLATORS_COLUMNS = [
+    "last_name",
+    "first_name",
+    "middle_name",
+    "suffix",
+    "nickname",
+    "full_name",
+    "birthday",
+    "gender",
+    "type",
+    "state",
+    "district",
+    "senate_class",
+    "party",
+    "url",
+    "address",
+    "phone",
+    "contact_form",
+    "rss_url",
+    "twitter",
+    "twitter_id",
+    "facebook",
+    "youtube",
+    "youtube_id",
+    "mastodon",
+    "bioguide_id",
+    "thomas_id",
+    "opensecrets_id",
+    "lis_id",
+    "fec_ids",
+    "cspan_id",
+    "govtrack_id",
+    "votesmart_id",
+    "ballotpedia_id",
+    "washington_post_id",
+    "icpsr_id",
+    "wikipedia_id",
+]
+
+
+# =============================================================================
+# FILE TYPE CONFIGURATION
+# =============================================================================
+@dataclass
+class FileTypeConfig:
+    """Configuration for a specific Congress Legislators file type."""
+
+    schema: dict[str, pa.DataType]
+    expected_columns: list[str]
+    sum_column: str | None  # No numeric columns to sum for this dataset
+    key_columns: list[str]  # Columns to track non-null counts
+    sample_size: int = 1000  # Default sample size for validation
+
+
+FILE_TYPE_CONFIGS: dict[FileType, FileTypeConfig] = {
+    FileType.CURRENT: FileTypeConfig(
+        schema=LEGISLATORS_SCHEMA,
+        expected_columns=LEGISLATORS_COLUMNS,
+        sum_column=None,  # All string columns, no numeric sum
+        key_columns=["bioguide_id", "icpsr_id", "state", "type"],
+        sample_size=500,  # Current legislators is smaller (~540 rows)
+    ),
+    FileType.HISTORICAL: FileTypeConfig(
+        schema=LEGISLATORS_SCHEMA,
+        expected_columns=LEGISLATORS_COLUMNS,
+        sum_column=None,  # All string columns, no numeric sum
+        key_columns=["bioguide_id", "icpsr_id", "state", "type"],
+        sample_size=1000,  # Historical has ~12,500 rows
+    ),
+}
+
+
+def get_config(file_type: FileType) -> FileTypeConfig:
+    """Get configuration for a file type."""
+    return FILE_TYPE_CONFIGS[file_type]
+
+
+# Null markers in Congress Legislators CSVs
+NULL_VALUES = [""]
+
+# Download URLs
+BASE_URL = "https://unitedstates.github.io/congress-legislators"
+FILE_URLS = {
+    FileType.CURRENT: f"{BASE_URL}/legislators-current.csv",
+    FileType.HISTORICAL: f"{BASE_URL}/legislators-historical.csv",
+}

--- a/scripts/congress_legislators_converter/validators.py
+++ b/scripts/congress_legislators_converter/validators.py
@@ -1,0 +1,263 @@
+"""Three-tier validation suite for Congress Legislators parquet conversions."""
+
+from __future__ import annotations
+
+import csv
+import math
+import random
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+
+from .exceptions import (
+    ChecksumMismatchError,
+    RowCountMismatchError,
+    SampleMismatchError,
+)
+
+if TYPE_CHECKING:
+    from .converter import StreamingStats
+
+
+@dataclass
+class ValidationResult:
+    """Results from validation suite."""
+
+    row_count_valid: bool = False
+    row_count_expected: int = 0
+    row_count_actual: int = 0
+
+    checksum_valid: bool = False
+    sum_column_name: str | None = None
+    sum_column_expected: float = 0.0
+    sum_column_actual: float = 0.0
+    non_null_counts: dict[str, tuple[int, int]] = field(default_factory=dict)
+
+    sample_valid: bool = False
+    sample_size: int = 0
+
+    @property
+    def all_valid(self) -> bool:
+        """Check if all validation tiers passed."""
+        return self.row_count_valid and self.checksum_valid and self.sample_valid
+
+
+def validate_row_count(
+    source_path: Path,
+    output_path: Path,
+    expected_count: int,
+) -> ValidationResult:
+    """
+    Tier 1: Verify row counts match using parquet metadata.
+
+    This is the fastest validation - reads only metadata, no actual data.
+    """
+    meta = pq.read_metadata(output_path)
+    actual_count = meta.num_rows
+
+    result = ValidationResult(
+        row_count_expected=expected_count,
+        row_count_actual=actual_count,
+    )
+
+    if actual_count != expected_count:
+        raise RowCountMismatchError(
+            source_path=source_path,
+            message="Row count validation failed",
+            expected_rows=expected_count,
+            actual_rows=actual_count,
+        )
+
+    result.row_count_valid = True
+    return result
+
+
+def validate_checksums(
+    source_path: Path,
+    output_path: Path,
+    source_stats: StreamingStats,
+    result: ValidationResult,
+    sum_column: str | None,
+    key_columns: list[str] | None = None,
+) -> ValidationResult:
+    """
+    Tier 2: Verify column checksums.
+
+    Validates:
+    - Sum of configurable numeric column (not applicable for string-only datasets)
+    - Non-null counts for key columns (detects dropped data)
+    """
+    if key_columns is None:
+        key_columns = []
+
+    result.sum_column_name = sum_column
+
+    # Checksum 1: Sum validation (skipped for string-only datasets)
+    if sum_column:
+        source_sum = source_stats.sum_column_value
+        sum_table = pq.read_table(output_path, columns=[sum_column])
+        parquet_sum = pc.sum(sum_table.column(sum_column)).as_py() or 0.0
+
+        result.sum_column_expected = source_sum
+        result.sum_column_actual = parquet_sum
+
+        # Allow tiny floating point tolerance
+        if abs(source_sum - parquet_sum) > 0.01:
+            raise ChecksumMismatchError(
+                source_path=source_path,
+                message=f"{sum_column} sum mismatch",
+                column_name=sum_column,
+                expected_value=source_sum,
+                actual_value=parquet_sum,
+            )
+
+    # Checksum 2: Non-null count validation
+    for col in key_columns:
+        source_count = source_stats.non_null_counts.get(col, 0)
+        col_table = pq.read_table(output_path, columns=[col])
+        parquet_count = pc.count(col_table.column(col)).as_py()
+
+        result.non_null_counts[col] = (source_count, parquet_count)
+
+        if source_count != parquet_count:
+            raise ChecksumMismatchError(
+                source_path=source_path,
+                message=f"Non-null count mismatch for {col}",
+                column_name=col,
+                expected_value=source_count,
+                actual_value=parquet_count,
+            )
+
+    result.checksum_valid = True
+    return result
+
+
+def validate_sample_rows(
+    source_path: Path,
+    output_path: Path,
+    sample_size: int,
+    result: ValidationResult,
+) -> ValidationResult:
+    """
+    Tier 3: Compare random sample of rows field-by-field.
+
+    Most thorough validation - catches subtle conversion errors.
+    Memory-efficient: reads parquet in batches, captures only sample rows.
+    """
+    meta = pq.read_metadata(output_path)
+    total_rows = meta.num_rows
+
+    # Adjust sample size if file is smaller
+    actual_sample_size = min(sample_size, total_rows)
+    sample_indices = sorted(random.sample(range(total_rows), actual_sample_size))
+
+    # Read source CSV rows at sample indices
+    source_rows = _read_csv_rows_at_indices(source_path, sample_indices)
+
+    # Read parquet in batches, capturing sample rows
+    parquet_file = pq.ParquetFile(output_path)
+    schema_names = parquet_file.schema_arrow.names
+
+    index_to_position = {idx: pos for pos, idx in enumerate(sample_indices)}
+    parquet_sample_rows: list[dict[str, Any] | None] = [None] * len(sample_indices)
+
+    current_row = 0
+    for batch in parquet_file.iter_batches():
+        batch_end = current_row + batch.num_rows
+
+        for sample_idx in sample_indices:
+            if current_row <= sample_idx < batch_end:
+                local_idx = sample_idx - current_row
+                row_dict: dict[str, Any] = {}
+                for col_name in schema_names:
+                    row_dict[col_name] = batch.column(col_name)[local_idx].as_py()
+                parquet_sample_rows[index_to_position[sample_idx]] = row_dict
+
+        current_row = batch_end
+
+        # Early exit if we've captured all sample rows
+        if all(r is not None for r in parquet_sample_rows):
+            break
+
+    # Compare rows field by field
+    result.sample_size = len(sample_indices)
+    for i, row_idx in enumerate(sample_indices):
+        source_row = source_rows[i]
+        parquet_row = parquet_sample_rows[i]
+
+        for col_name in schema_names:
+            source_val = source_row.get(col_name) if source_row else None
+            parquet_val = parquet_row.get(col_name) if parquet_row else None
+
+            source_normalized = _normalize_value(source_val)
+            parquet_normalized = _normalize_value(parquet_val)
+
+            if not _values_equal(source_normalized, parquet_normalized):
+                raise SampleMismatchError(
+                    source_path=source_path,
+                    message="Sample row mismatch",
+                    row_index=row_idx,
+                    column_name=col_name,
+                    expected_value=str(source_normalized),
+                    actual_value=str(parquet_normalized),
+                )
+
+    result.sample_valid = True
+    return result
+
+
+def _read_csv_rows_at_indices(path: Path, indices: list[int]) -> list[dict[str, str] | None]:
+    """Read specific rows from plain CSV by index."""
+    indices_set = set(indices)
+    index_to_position = {idx: pos for pos, idx in enumerate(sorted(indices))}
+    rows: list[dict[str, str] | None] = [None] * len(indices)
+
+    with path.open(encoding="utf-8") as f:
+        reader = csv.DictReader(f, doublequote=True)
+        for i, row in enumerate(reader):
+            if i in indices_set:
+                rows[index_to_position[i]] = row
+                if all(r is not None for r in rows):
+                    break
+
+    return rows
+
+
+def _normalize_value(val: Any) -> Any:
+    """Normalize values for comparison."""
+    if val is None or val == "":
+        return None
+    if isinstance(val, float):
+        if math.isnan(val):
+            return None
+        return round(val, 6)
+    if isinstance(val, str):
+        stripped = val.strip()
+        # Treat various null representations as None
+        if stripped.lower() in ("nan", "n/a", "na", "null"):
+            return None
+        return stripped
+    return val
+
+
+def _values_equal(a: Any, b: Any) -> bool:
+    """Compare two normalized values with tolerance for floats."""
+    if a is None and b is None:
+        return True
+    if a is None or b is None:
+        return False
+
+    # Try numeric comparison with tolerance
+    try:
+        a_float = float(a) if isinstance(a, str) else a
+        b_float = float(b) if isinstance(b, str) else b
+        if isinstance(a_float, (int, float)) and isinstance(b_float, (int, float)):
+            return abs(float(a_float) - float(b_float)) < 0.000001
+    except (ValueError, TypeError):
+        pass
+
+    # String comparison
+    return str(a) == str(b)

--- a/scripts/uv.lock
+++ b/scripts/uv.lock
@@ -1,0 +1,50 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "dime-converter"
+version = "1.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pyarrow" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pyarrow", specifier = ">=15.0.0" }]
+
+[[package]]
+name = "pyarrow"
+version = "22.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/53/04a7fdc63e6056116c9ddc8b43bc28c12cdd181b85cbeadb79278475f3ae/pyarrow-22.0.0.tar.gz", hash = "sha256:3d600dc583260d845c7d8a6db540339dd883081925da2bd1c5cb808f720b3cd9", size = 1151151, upload-time = "2025-10-24T12:30:00.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/d6/d0fac16a2963002fc22c8fa75180a838737203d558f0ed3b564c4a54eef5/pyarrow-22.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e6e95176209257803a8b3d0394f21604e796dadb643d2f7ca21b66c9c0b30c9a", size = 34204629, upload-time = "2025-10-24T10:06:20.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9c/1d6357347fbae062ad3f17082f9ebc29cc733321e892c0d2085f42a2212b/pyarrow-22.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:001ea83a58024818826a9e3f89bf9310a114f7e26dfe404a4c32686f97bd7901", size = 35985783, upload-time = "2025-10-24T10:06:27.301Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c0/782344c2ce58afbea010150df07e3a2f5fdad299cd631697ae7bd3bac6e3/pyarrow-22.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:ce20fe000754f477c8a9125543f1936ea5b8867c5406757c224d745ed033e691", size = 45020999, upload-time = "2025-10-24T10:06:35.387Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8b/5362443737a5307a7b67c1017c42cd104213189b4970bf607e05faf9c525/pyarrow-22.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e0a15757fccb38c410947df156f9749ae4a3c89b2393741a50521f39a8cf202a", size = 47724601, upload-time = "2025-10-24T10:06:43.551Z" },
+    { url = "https://files.pythonhosted.org/packages/69/4d/76e567a4fc2e190ee6072967cb4672b7d9249ac59ae65af2d7e3047afa3b/pyarrow-22.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cedb9dd9358e4ea1d9bce3665ce0797f6adf97ff142c8e25b46ba9cdd508e9b6", size = 48001050, upload-time = "2025-10-24T10:06:52.284Z" },
+    { url = "https://files.pythonhosted.org/packages/01/5e/5653f0535d2a1aef8223cee9d92944cb6bccfee5cf1cd3f462d7cb022790/pyarrow-22.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:252be4a05f9d9185bb8c18e83764ebcfea7185076c07a7a662253af3a8c07941", size = 50307877, upload-time = "2025-10-24T10:07:02.405Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f8/1d0bd75bf9328a3b826e24a16e5517cd7f9fbf8d34a3184a4566ef5a7f29/pyarrow-22.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:a4893d31e5ef780b6edcaf63122df0f8d321088bb0dee4c8c06eccb1ca28d145", size = 27977099, upload-time = "2025-10-24T10:08:07.259Z" },
+    { url = "https://files.pythonhosted.org/packages/90/81/db56870c997805bf2b0f6eeeb2d68458bf4654652dccdcf1bf7a42d80903/pyarrow-22.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:f7fe3dbe871294ba70d789be16b6e7e52b418311e166e0e3cba9522f0f437fb1", size = 34336685, upload-time = "2025-10-24T10:07:11.47Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/98/0727947f199aba8a120f47dfc229eeb05df15bcd7a6f1b669e9f882afc58/pyarrow-22.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:ba95112d15fd4f1105fb2402c4eab9068f0554435e9b7085924bcfaac2cc306f", size = 36032158, upload-time = "2025-10-24T10:07:18.626Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b4/9babdef9c01720a0785945c7cf550e4acd0ebcd7bdd2e6f0aa7981fa85e2/pyarrow-22.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c064e28361c05d72eed8e744c9605cbd6d2bb7481a511c74071fd9b24bc65d7d", size = 44892060, upload-time = "2025-10-24T10:07:26.002Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ca/2f8804edd6279f78a37062d813de3f16f29183874447ef6d1aadbb4efa0f/pyarrow-22.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6f9762274496c244d951c819348afbcf212714902742225f649cf02823a6a10f", size = 47504395, upload-time = "2025-10-24T10:07:34.09Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f0/77aa5198fd3943682b2e4faaf179a674f0edea0d55d326d83cb2277d9363/pyarrow-22.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a9d9ffdc2ab696f6b15b4d1f7cec6658e1d788124418cb30030afbae31c64746", size = 48066216, upload-time = "2025-10-24T10:07:43.528Z" },
+    { url = "https://files.pythonhosted.org/packages/79/87/a1937b6e78b2aff18b706d738c9e46ade5bfcf11b294e39c87706a0089ac/pyarrow-22.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ec1a15968a9d80da01e1d30349b2b0d7cc91e96588ee324ce1b5228175043e95", size = 50288552, upload-time = "2025-10-24T10:07:53.519Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ae/b5a5811e11f25788ccfdaa8f26b6791c9807119dffcf80514505527c384c/pyarrow-22.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:bba208d9c7decf9961998edf5c65e3ea4355d5818dd6cd0f6809bec1afb951cc", size = 28262504, upload-time = "2025-10-24T10:08:00.932Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b0/0fa4d28a8edb42b0a7144edd20befd04173ac79819547216f8a9f36f9e50/pyarrow-22.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:9bddc2cade6561f6820d4cd73f99a0243532ad506bc510a75a5a65a522b2d74d", size = 34224062, upload-time = "2025-10-24T10:08:14.101Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a8/7a719076b3c1be0acef56a07220c586f25cd24de0e3f3102b438d18ae5df/pyarrow-22.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e70ff90c64419709d38c8932ea9fe1cc98415c4f87ea8da81719e43f02534bc9", size = 35990057, upload-time = "2025-10-24T10:08:21.842Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3c/359ed54c93b47fb6fe30ed16cdf50e3f0e8b9ccfb11b86218c3619ae50a8/pyarrow-22.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:92843c305330aa94a36e706c16209cd4df274693e777ca47112617db7d0ef3d7", size = 45068002, upload-time = "2025-10-24T10:08:29.034Z" },
+    { url = "https://files.pythonhosted.org/packages/55/fc/4945896cc8638536ee787a3bd6ce7cec8ec9acf452d78ec39ab328efa0a1/pyarrow-22.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:6dda1ddac033d27421c20d7a7943eec60be44e0db4e079f33cc5af3b8280ccde", size = 47737765, upload-time = "2025-10-24T10:08:38.559Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5e/7cb7edeb2abfaa1f79b5d5eb89432356155c8426f75d3753cbcb9592c0fd/pyarrow-22.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:84378110dd9a6c06323b41b56e129c504d157d1a983ce8f5443761eb5256bafc", size = 48048139, upload-time = "2025-10-24T10:08:46.784Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c6/546baa7c48185f5e9d6e59277c4b19f30f48c94d9dd938c2a80d4d6b067c/pyarrow-22.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:854794239111d2b88b40b6ef92aa478024d1e5074f364033e73e21e3f76b25e0", size = 50314244, upload-time = "2025-10-24T10:08:55.771Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/79/755ff2d145aafec8d347bf18f95e4e81c00127f06d080135dfc86aea417c/pyarrow-22.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:b883fe6fd85adad7932b3271c38ac289c65b7337c2c132e9569f9d3940620730", size = 28757501, upload-time = "2025-10-24T10:09:59.891Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/d2/237d75ac28ced3147912954e3c1a174df43a95f4f88e467809118a8165e0/pyarrow-22.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7a820d8ae11facf32585507c11f04e3f38343c1e784c9b5a8b1da5c930547fe2", size = 34355506, upload-time = "2025-10-24T10:09:02.953Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/733dfffe6d3069740f98e57ff81007809067d68626c5faef293434d11bd6/pyarrow-22.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:c6ec3675d98915bf1ec8b3c7986422682f7232ea76cad276f4c8abd5b7319b70", size = 36047312, upload-time = "2025-10-24T10:09:10.334Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/2b/29d6e3782dc1f299727462c1543af357a0f2c1d3c160ce199950d9ca51eb/pyarrow-22.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:3e739edd001b04f654b166204fc7a9de896cf6007eaff33409ee9e50ceaff754", size = 45081609, upload-time = "2025-10-24T10:09:18.61Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/42/aa9355ecc05997915af1b7b947a7f66c02dcaa927f3203b87871c114ba10/pyarrow-22.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7388ac685cab5b279a41dfe0a6ccd99e4dbf322edfb63e02fc0443bf24134e91", size = 47703663, upload-time = "2025-10-24T10:09:27.369Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/62/45abedde480168e83a1de005b7b7043fd553321c1e8c5a9a114425f64842/pyarrow-22.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f633074f36dbc33d5c05b5dc75371e5660f1dbf9c8b1d95669def05e5425989c", size = 48066543, upload-time = "2025-10-24T10:09:34.908Z" },
+    { url = "https://files.pythonhosted.org/packages/84/e9/7878940a5b072e4f3bf998770acafeae13b267f9893af5f6d4ab3904b67e/pyarrow-22.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4c19236ae2402a8663a2c8f21f1870a03cc57f0bef7e4b6eb3238cc82944de80", size = 50288838, upload-time = "2025-10-24T10:09:44.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/03/f335d6c52b4a4761bcc83499789a1e2e16d9d201a58c327a9b5cc9a41bd9/pyarrow-22.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0c34fe18094686194f204a3b1787a27456897d8a2d62caf84b61e8dfbc0252ae", size = 29185594, upload-time = "2025-10-24T10:09:53.111Z" },
+]

--- a/uv.lock
+++ b/uv.lock
@@ -767,6 +767,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "duckdb-loader" },
+    { name = "huggingface-hub" },
 ]
 
 [package.optional-dependencies]
@@ -784,6 +785,7 @@ dev = [
 requires-dist = [
     { name = "duckdb", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "duckdb-loader", editable = "duckdb_loader" },
+    { name = "huggingface-hub", specifier = ">=1.2.3" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },


### PR DESCRIPTION
## Summary
- Add new converter module for United States Congress Legislators data
- Fix HuggingFace dataset paths in README (remove nested `tyt/` prefix)
- Add `huggingface-hub` dependency for dataset uploads

## Changes
- `scripts/congress_legislators_converter/` - New 8-file module following voteview_converter patterns
- Downloads from unitedstates.github.io (legislators-current.csv, legislators-historical.csv)
- Converts to Parquet with lossless validation (all 36 columns as strings)
- Three-tier validation: row count, checksums, sample comparison
- README updates with correct paths and new data source documentation

## Data uploaded to HuggingFace
- `unitedstates_congress_github/legislators-current.parquet` (540 rows)
- `unitedstates_congress_github/legislators-historical.parquet` (12,222 rows)

## Test plan
- [x] Converter runs successfully on both files
- [x] All validation tiers pass
- [x] Files uploaded to HuggingFace and accessible
- [x] README paths verified correct